### PR TITLE
Add injectOptions to BlocklyDrawer's props

### DIFF
--- a/build/BlocklyDrawer.js
+++ b/build/BlocklyDrawer.js
@@ -67,7 +67,7 @@ var BlocklyDrawer = function (_Component) {
         window.addEventListener('resize', this.onResize, false);
         this.onResize();
 
-        var workspacePlayground = _browser2.default.inject(this.content, { toolbox: this.toolbox });
+        var workspacePlayground = _browser2.default.inject(this.content, Object.assign({ toolbox: this.toolbox }, this.props.injectOptions));
 
         if (this.props.workspaceXML) {
           _browser2.default.Xml.domToWorkspace(_browser2.default.Xml.textToDom(this.props.workspaceXML), workspacePlayground);
@@ -149,7 +149,8 @@ var BlocklyDrawer = function (_Component) {
 BlocklyDrawer.defaultProps = {
   onChange: function onChange() {},
   tools: [],
-  workspaceXML: ''
+  workspaceXML: '',
+  injectOptions: {}
 };
 
 BlocklyDrawer.propTypes = {
@@ -161,7 +162,8 @@ BlocklyDrawer.propTypes = {
   })).isRequired,
   onChange: _propTypes2.default.func,
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node]),
-  workspaceXML: _propTypes2.default.string
+  workspaceXML: _propTypes2.default.string,
+  injectOptions: _propTypes2.default.object
 };
 
 styles = {

--- a/src/BlocklyDrawer.js
+++ b/src/BlocklyDrawer.js
@@ -35,7 +35,10 @@ class BlocklyDrawer extends Component {
   
       const workspacePlayground = Blockly.inject(
         this.content,
-        { toolbox: this.toolbox }
+        Object.assign(
+            { toolbox: this.toolbox },
+            this.props.injectOptions
+        )
       );
   
       if (this.props.workspaceXML) {
@@ -116,6 +119,7 @@ BlocklyDrawer.defaultProps = {
   onChange: () => {},
   tools: [],
   workspaceXML: '',
+  injectOptions: {},
 };
 
 BlocklyDrawer.propTypes = {
@@ -131,6 +135,7 @@ BlocklyDrawer.propTypes = {
     PropTypes.node
   ]),
   workspaceXML: PropTypes.string,
+  injectOptions: PropTypes.object,
 };
 
 styles = {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -143,5 +143,14 @@ describe('BlocklyDrawerComponent', () => {
             Blockly.Xml.domToWorkspace.mock.calls[0][1]
         ).toBe(playground);
     });
+
+    it('passes injectOptions to inject', () => {
+        const comp = mount(
+            <Drawer
+                injectOptions={{foo: 42}}
+            />
+        );
+        expect(Blockly.inject.mock.calls[0][1].foo).toBe(42);
+    });
 })
 


### PR DESCRIPTION
I work on a project in which I need to have the toolbox on the right-hand side but the current implementation of `BlocklyDrawer` does not support additional arguments to `Blockly.inject`.

I added `injectOptions` to `this.props`, which are then passed to `inject`.

There's not much code, but please check carefully; I'm a newbie in react and javascript, and I can't be trusted. :)