### PR TITLE
Synchronize workspace xml

### DIFF
--- a/build/BlocklyDrawer.js
+++ b/build/BlocklyDrawer.js
@@ -67,7 +67,7 @@ var BlocklyDrawer = function (_Component) {
         window.addEventListener('resize', this.onResize, false);
         this.onResize();
 
-        var workspacePlayground = _browser2.default.inject(this.content, { toolbox: this.toolbox });
+        var workspacePlayground = _browser2.default.inject(this.content, { toolbox: this.toolbox, ...this.props.injectOptions });
 
         if (this.props.workspaceXML) {
           _browser2.default.Xml.domToWorkspace(_browser2.default.Xml.textToDom(this.props.workspaceXML), workspacePlayground);
@@ -149,7 +149,8 @@ var BlocklyDrawer = function (_Component) {
 BlocklyDrawer.defaultProps = {
   onChange: function onChange() {},
   tools: [],
-  workspaceXML: ''
+  workspaceXML: '',
+  injectOptions: {}
 };
 
 BlocklyDrawer.propTypes = {
@@ -161,7 +162,8 @@ BlocklyDrawer.propTypes = {
   })).isRequired,
   onChange: _propTypes2.default.func,
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node]),
-  workspaceXML: _propTypes2.default.string
+  workspaceXML: _propTypes2.default.string,
+  injectOptions: _propTypes2.default.object
 };
 
 styles = {

--- a/build/BlocklyDrawer.js
+++ b/build/BlocklyDrawer.js
@@ -67,19 +67,19 @@ var BlocklyDrawer = function (_Component) {
         window.addEventListener('resize', this.onResize, false);
         this.onResize();
 
-        var workspacePlayground = _browser2.default.inject(this.content, { toolbox: this.toolbox, ...this.props.injectOptions });
+        this.workspacePlayground = _browser2.default.inject(this.content, { toolbox: this.toolbox, ...this.props.injectOptions });
 
         if (this.props.workspaceXML) {
-          _browser2.default.Xml.domToWorkspace(_browser2.default.Xml.textToDom(this.props.workspaceXML), workspacePlayground);
+          _browser2.default.Xml.domToWorkspace(_browser2.default.Xml.textToDom(this.props.workspaceXML), this.workspacePlayground);
         }
 
-        _browser2.default.svgResize(workspacePlayground);
+        _browser2.default.svgResize(this.workspacePlayground);
 
-        workspacePlayground.addChangeListener(function () {
-          var code = _browser2.default.JavaScript.workspaceToCode(workspacePlayground);
-          var xml = _browser2.default.Xml.workspaceToDom(workspacePlayground);
+        this.workspacePlayground.addChangeListener(function () {
+        //  var code = _browser2.default.JavaScript.workspaceToCode(workspacePlayground);
+          var xml = _browser2.default.Xml.workspaceToDom(_this2.workspacePlayground);
           var xmlText = _browser2.default.Xml.domToText(xml);
-          _this2.props.onChange(code, xmlText);
+          _this2.props.onChange(xmlText);
         });
       }
     }
@@ -87,6 +87,12 @@ var BlocklyDrawer = function (_Component) {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
       initTools(nextProps.tools);
+      this.workspacePlayground.clear()
+      if (nextProps.workspaceXML) {
+          _browser2.default.Xml.domToWorkspace(
+              _browser2.default.Xml.textToDom(nextProps.workspaceXML),
+              this.workspacePlayground);
+      }
     }
   }, {
     key: 'componentWillUnmount',


### PR DESCRIPTION
**Note:** This PR is based on #4 to avoid merge conflicts. The actual change is only in the commit https://github.com/xvicmanx/react-blockly-drawer/commit/54a7592dcc7c8433c2a0f3a7fdc10873f54b724b


#### Issue

In my project, the user uses blocks to program different "scenes". (S)he can program one scene, switch to another and work on it for some time, then go back to the first scene... At every switch, I need to store and retrieve the current configuration of blocks in the workspace. (I could share the project, but it's so disorganized at the moment that I won't even put it on github yet.)

React-blockly-drawer supports only storing the scheme, through the `onChange` event. But I can't restore it because I have no (nice) access to `workspacePlayground` (except by hacking through DOM elements) nor does it reset the workspace through props.

#### Changes

I implemented this for my needs, but being a newbie in Javascript and React, I don't know whether this is a proper way to do it -- and whether you like this functionality at all. Don't hesitate to reject the PR or to instruct me to do it in some other way.

#### Open issue: Code generation

I commented out the code for generating Javascript - because I won't generate it in my project, and I believe that there will be other such cases in the future, too. However, this breaks backward compatibility. I think the proper way would be to check if the code can be generated; if yes, `onChange` is called with the `code` string, as before, and if not, only `xml` is passed. I don't know how to do this properly, so I wait for your guidance.

A better solution could be to allow specifying the generator (what if one wants Python code?) or to simply send the workspace as an argument to the `onChange` handler.