### PR TITLE
Allow changing a language or remove code generation; use prop workspace on re-rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ import BlocklyDrawer, { Block, Category } from 'react-blockly-drawer';
 
 #### `onChange`: function (code, workspaceXML) {}
 Event listener to the workspace change.  Two arguments are passed to this callback:
-- `code` that is the generated code of your created program.
-- `workspaceXML` that is an XML text that corresponds to the content of the workspace.
+- `code` is the generated code of your created program (see the property
+  `language`);
+- `workspaceXML` is an XML text that corresponds to the content of the workspace.
+
+#### `language`: object [optional]
+A language generator, either one of the languages described in the
+[Blockly documentation on code generation](https://developers.google.com/blockly/guides/configure/web/code-generators) or
+a custom object with method `workspaceToCode`. Default generator is
+`Blockly.Javascript`. If `language` is set to `null`, no code is generated and
+the first argument passed to the `onChange` function, `code` will be `null`.
 
 #### `children`:  node(s)
 Blockly predefined blocks/tools can be passed as children of this component.

--- a/build/BlocklyDrawer.js
+++ b/build/BlocklyDrawer.js
@@ -67,7 +67,7 @@ var BlocklyDrawer = function (_Component) {
         window.addEventListener('resize', this.onResize, false);
         this.onResize();
 
-        var workspacePlayground = _browser2.default.inject(this.content, Object.assign({ toolbox: this.toolbox }, this.props.injectOptions));
+        this.workspacePlayground = _browser2.default.inject(this.content, Object.assign({ toolbox: this.toolbox }, this.props.injectOptions));
 
         if (this.props.workspaceXML) {
           _browser2.default.Xml.domToWorkspace(_browser2.default.Xml.textToDom(this.props.workspaceXML), this.workspacePlayground);
@@ -76,10 +76,10 @@ var BlocklyDrawer = function (_Component) {
         _browser2.default.svgResize(this.workspacePlayground);
 
         this.workspacePlayground.addChangeListener(function () {
-        //  var code = _browser2.default.JavaScript.workspaceToCode(workspacePlayground);
+          var code = _this2.props.language ? _this2.props.language.workspaceToCode(_this2.workspacePlayground) : null;
           var xml = _browser2.default.Xml.workspaceToDom(_this2.workspacePlayground);
           var xmlText = _browser2.default.Xml.domToText(xml);
-          _this2.props.onChange(xmlText);
+          _this2.props.onChange(code, xmlText);
         });
       }
     }
@@ -87,11 +87,10 @@ var BlocklyDrawer = function (_Component) {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
       initTools(nextProps.tools);
-      this.workspacePlayground.clear()
+      this.workspacePlayground.clear();
       if (nextProps.workspaceXML) {
-          _browser2.default.Xml.domToWorkspace(
-              _browser2.default.Xml.textToDom(nextProps.workspaceXML),
-              this.workspacePlayground);
+        var dom = _browser2.default.Xml.textToDom(nextProps.workspaceXML);
+        _browser2.default.Xml.domToWorkspace(dom, this.workspacePlayground);
       }
     }
   }, {
@@ -156,7 +155,8 @@ BlocklyDrawer.defaultProps = {
   onChange: function onChange() {},
   tools: [],
   workspaceXML: '',
-  injectOptions: {}
+  injectOptions: {},
+  language: _browser2.default.JavaScript
 };
 
 BlocklyDrawer.propTypes = {
@@ -169,7 +169,8 @@ BlocklyDrawer.propTypes = {
   onChange: _propTypes2.default.func,
   children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node]),
   workspaceXML: _propTypes2.default.string,
-  injectOptions: _propTypes2.default.object
+  injectOptions: _propTypes2.default.object,
+  language: _propTypes2.default.object
 };
 
 styles = {

--- a/src/BlocklyDrawer.js
+++ b/src/BlocklyDrawer.js
@@ -32,29 +32,31 @@ class BlocklyDrawer extends Component {
         false
       );
       this.onResize();
-  
-      const workspacePlayground = Blockly.inject(
+
+      this.workspacePlayground = Blockly.inject(
         this.content,
         Object.assign(
             { toolbox: this.toolbox },
             this.props.injectOptions
         )
       );
-  
+
       if (this.props.workspaceXML) {
         Blockly.Xml.domToWorkspace(
           Blockly.Xml.textToDom(
             this.props.workspaceXML
           ),
-          workspacePlayground
+          this.workspacePlayground
         );
       }
-      
-      Blockly.svgResize(workspacePlayground);
 
-      workspacePlayground.addChangeListener(() => {
-        const code = Blockly.JavaScript.workspaceToCode(workspacePlayground);
-        const xml = Blockly.Xml.workspaceToDom(workspacePlayground);
+      Blockly.svgResize(this.workspacePlayground);
+
+      this.workspacePlayground.addChangeListener(() => {
+        const code = this.props.language
+          ? this.props.language.workspaceToCode(this.workspacePlayground)
+          : null;
+        const xml = Blockly.Xml.workspaceToDom(this.workspacePlayground);
         const xmlText = Blockly.Xml.domToText(xml);
         this.props.onChange(code, xmlText);
       });
@@ -63,6 +65,11 @@ class BlocklyDrawer extends Component {
 
   componentWillReceiveProps(nextProps) {
     initTools(nextProps.tools);
+    this.workspacePlayground.clear();
+    if (nextProps.workspaceXML) {
+      const dom = Blockly.Xml.textToDom(nextProps.workspaceXML);
+      Blockly.Xml.domToWorkspace(dom, this.workspacePlayground);
+    }
   }
 
   componentWillUnmount() {
@@ -120,6 +127,7 @@ BlocklyDrawer.defaultProps = {
   tools: [],
   workspaceXML: '',
   injectOptions: {},
+  language: Blockly.JavaScript,
 };
 
 BlocklyDrawer.propTypes = {
@@ -136,6 +144,7 @@ BlocklyDrawer.propTypes = {
   ]),
   workspaceXML: PropTypes.string,
   injectOptions: PropTypes.object,
+  language: PropTypes.object,
 };
 
 styles = {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -152,5 +152,72 @@ describe('BlocklyDrawerComponent', () => {
         );
         expect(Blockly.inject.mock.calls[0][1].foo).toBe(42);
     });
+
+    it('allows redefining a language', () => {
+        const onChange = jest.fn();
+        const mockLanguage = {
+            workspaceToCode: jest.fn().mockReturnValue('more-test-code')
+        }
+        const comp = mount(<Drawer onChange={onChange} language={mockLanguage} />);
+
+        expect(
+            mockLanguage.workspaceToCode.mock.calls.length
+        ).toBe(1);
+        expect(
+            Blockly.Xml.workspaceToDom.mock.calls.length
+        ).toBe(1);
+        expect(
+            Blockly.Xml.domToText.mock.calls.length
+        ).toBe(1);
+        expect(
+            onChange.mock.calls.length
+        ).toBe(1);
+
+        expect(
+            mockLanguage.workspaceToCode.mock.calls[0][0]
+        ).toBe(playground);
+        expect(
+            Blockly.Xml.workspaceToDom.mock.calls[0][0]
+        ).toBe(playground);
+        expect(
+            Blockly.Xml.domToText.mock.calls[0][0]
+        ).toBe('test-xml');
+
+        expect(
+            onChange.mock.calls[0][0]
+        ).toBe('more-test-code');
+        expect(
+            onChange.mock.calls[0][1]
+        ).toBe('test-dom-text');
+    });
+
+    it('allows removing a language', () => {
+        const onChange = jest.fn();
+        const comp = mount(<Drawer onChange={onChange} language={null} />);
+
+        expect(
+            Blockly.Xml.workspaceToDom.mock.calls.length
+        ).toBe(1);
+        expect(
+            Blockly.Xml.domToText.mock.calls.length
+        ).toBe(1);
+        expect(
+            onChange.mock.calls.length
+        ).toBe(1);
+
+        expect(
+            Blockly.Xml.workspaceToDom.mock.calls[0][0]
+        ).toBe(playground);
+        expect(
+            Blockly.Xml.domToText.mock.calls[0][0]
+        ).toBe('test-xml');
+
+        expect(
+            onChange.mock.calls[0][0]
+        ).toBe(null);
+        expect(
+            onChange.mock.calls[0][1]
+        ).toBe('test-dom-text');
+    });
 })
 


### PR DESCRIPTION
A better alternative to the failed #5, which is now backward compatible with the existing code.

A new prop `language` can now specify a different language or it can be set to `null`, in which case no code is generated and `null` is passed to `onChange` as the first argument (`code`). Default language is `Blockly.JavaScript` to ensure backward compatilibity.

The new functionality is tested and documented.

The PR also uses the workspace prop on re-rendering (`componentWillReceiveProps`). I don't know how to properly test this. Changes in documentation are unnecessary since this is the expected behaviour.

There's a potential bug: `componentWillReceiveProps` could, in principle, receive a different language than the one used initially (`componentDidMount`). I wouldn't worry to much about switching languages, though.