### PR TITLE
changes references to components to be blockly components

### DIFF
--- a/src/ToolBoxTagsComponents.js
+++ b/src/ToolBoxTagsComponents.js
@@ -1,11 +1,17 @@
 import React, { Component } from 'react';
 
-export const Block = (props) => {
-    return React.createElement('block', props)
+export const Block = (p) => {
+    const { children, ...props } = p;
+    props.is = "blockly";
+    return React.createElement("block", props, children);
 };
-export const Category = (props) => {
-    return React.createElement('category', props);
+
+export const Category = (p) => {
+    const { children, ...props } = p;
+    props.is = "blockly";
+    return React.createElement("category", props, children);
 };
+
 
 class XmlComponent extends Component {
     render() {
@@ -16,6 +22,7 @@ class XmlComponent extends Component {
                 ref: (x) => this.props.onRef(x)
             });
         delete injectedProps.onRef;
+        injectedProps.is = "blockly";
         return React.createElement('xml', injectedProps);
     }
 };


### PR DESCRIPTION
Works to stop the warnings described in issue #1 (https://github.com/xvicmanx/react-blockly-drawer/issues/1), but I'm not able to pass tests. Actually, I've never run tests before on a package like this so I think it's me and not the new code...