### PR TITLE
pass language on componentDidUpdate

### DIFF
--- a/src/BlocklyDrawer.js
+++ b/src/BlocklyDrawer.js
@@ -62,7 +62,7 @@ class BlocklyDrawer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    initTools(this.props.tools);
+    initTools(this.props.tools, this.props.language);
     this.workspacePlayground.clear();
 
     if (this.props.workspaceXML) {


### PR DESCRIPTION
I was using Blockly to generate Python code and when the BlocklyDrawer component udpate I was losing the initial language that I was passing through the props and then I was getting the error `Uncaught Error: Language "Python" does not know how to generate  code for block type`, because in the update the blocks change to JavaScript code.
Checking the code I realize that there was 1 missing argument in the function that generate the custom blocks when the component update.